### PR TITLE
Added additional checks for GD image library

### DIFF
--- a/problems.php
+++ b/problems.php
@@ -216,8 +216,19 @@ class ProblemsPlugin extends Plugin
 
         // Check for GD library
         if (defined('GD_VERSION') && function_exists('gd_info')) {
-            $gd_adjective = '';
-            $gd_status = 'success';
+            $ginfo = gd_info();
+            $gda = array("PNG Support", "JPEG Support", "FreeType Support", "GIF Read Support");
+            foreach ($gda as $image_type) {
+                if ($ginfo[$image_type]) {
+                    $gd_adjective = '';
+                    $gd_status = 'success';
+                } else {
+                    $problems_found = true;
+                    $gd_adjective = "missing $image_type, but is ";
+                    $gd_status = 'warning';
+                    break;
+                }
+            }
         } else {
             $problems_found = true;
             $gd_adjective = 'not ';


### PR DESCRIPTION
It is possible to have GD installed without JPEG support. 
Without JPEG support in GD image manipulation of JPEG images will result in the fallback image being displayed. But no errors will propagate to the logs or debugger, even with all error reporting on.
In my case, I used the official PHP docker 7.2.9-cli-alpine3.8 and installed gd with their helper script docker-php-ext-install. However, this installs GD without jpeg support.
Since there were no errors it was a long rabbit hole I had to jump down before I found that jpeg image types weren't being supported.