### PR TITLE
Make sure the Essential Folders are listed without extra '/' in front of them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 12/28/2022
+
+1. [](#improved)
+   * Make sure the Essential Folders are listed without extra '/' in front of them
+
 # v2.1.1
 ## 04/14/2021
 

--- a/classes/Problems/EssentialFolders.php
+++ b/classes/Problems/EssentialFolders.php
@@ -51,6 +51,7 @@ class EssentialFolders extends Problem
 
         foreach ($essential_folders as $file => $check_writable) {
             $file_path = (!preg_match('`^(/|[a-z]:[\\\/])`ui', $file) ? GRAV_ROOT . '/' : '') . $file;
+            $file_path = preg_replace('`^/*`', '/', $file_path);
 
             if (!is_dir($file_path)) {
                 $file_errors[$file_path] = 'does not exist';


### PR DESCRIPTION
This pull request is related to my pull request https://github.com/getgrav/grav/pull/3667.

I use a hosting service where both GRAV_ROOT and GRAV_WEBROOT are `/`. Fixing problems caused by this arrangement in other Grav components makes the “essential folders” reported via admin plugin displayed with extra `/` in front of them. This fix contains a little `preg_replace` to replace multiple `/` characters in front of the paths with a single one.