### PR TITLE
Clarify Apache module detection text wording

### DIFF
--- a/classes/Problems/Apache.php
+++ b/classes/Problems/Apache.php
@@ -52,7 +52,7 @@ class Apache extends Problem
 
             $this->details = ['errors' => $apache_errors, 'success' => $apache_success];
         } else {
-            $this->msg = 'Apache not installed, skipping...';
+            $this->msg = 'Apache is not installed or PHP is not installed as Apache module, skipping...';
         }
 
         return $this;


### PR DESCRIPTION
apache_get_modules() works only if PHP is installed as Apache module (mod_php). If PHP is installed as CGI, for example php-fpm, current text incorrectly states that Apache is not installed.
In theory modules can be retrieved with "httpd -M" or "apache2ctl -M", however under different OSes it outputs module list in different format so it could be a little bit complicated to implement. Thus, I have only clarified the text.