### PR TITLE
Fix permission warning on Windows

### DIFF
--- a/classes/Problems/Permissions.php
+++ b/classes/Problems/Permissions.php
@@ -25,6 +25,12 @@ class Permissions extends Problem
      */
     public function process()
     {
+        if (PHP_OS_FAMILY === 'Windows') {
+            $this->msg = 'Permission check is not available for Windows.';
+            $this->status = true;
+            return $this;
+        }
+
         umask($umask = umask(022));
 
         $msg = 'Your default file umask is <strong>%s</strong> which %s';


### PR DESCRIPTION
Permission check is not available for Windows

fixes #45
